### PR TITLE
bulkeditモードで選択が行えない問題の修正

### DIFF
--- a/ext/src/inject/inject.js
+++ b/ext/src/inject/inject.js
@@ -8,9 +8,11 @@
 
       Array.prototype.forEach.call($item_links, function (elm, idx) {
         elm.href = originalUrls[idx];
-        elm.addEventListener('click', function (e) {
-          e.stopImmediatePropagation();
-        })
+        if (document.getElementById('queue').classList.length === 3) {
+          elm.addEventListener('click', function (e) {
+            e.stopImmediatePropagation();
+          });
+        }
       });
     }, 0);
   };


### PR DESCRIPTION
複数選択して削除するなどの操作を行う際に選択が行えず、リンクを展開してしまう問題に対する修正です。
Pocketのホーム画面の右上のペンマーク(Bulk Edit)を押下すると要素のクラスが追加されるのでそのクラス分の長さを見て分岐する処理を書いただけですが、Pocket側でclass関連の変更が入るとよくない挙動をとる可能性もあります。

私のユースケースにてほしいと思った操作のための処理追加になりますので、もし不都合でしたらcloseして下さい。